### PR TITLE
add missing raw_message_delivery typ

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -10,6 +10,7 @@ locals {
       protocol               = "lambda"
       endpoint               = "some_arn"
       endpoint_auto_confirms = true
+      raw_message_delivery   = true
     },
     {
       name                   = "random_named2"
@@ -17,6 +18,7 @@ locals {
       protocol               = "lambda"
       endpoint               = "some_arn2"
       endpoint_auto_confirms = false
+      raw_message_delivery   = false
     },
   ]
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -11,7 +11,7 @@ locals {
       endpoint               = "some_arn"
       endpoint_auto_confirms = true
       raw_message_delivery   = true
-      filter_policy = ""
+      filter_policy          = ""
     },
     {
       name                   = "random_named2"
@@ -20,7 +20,7 @@ locals {
       endpoint               = "some_arn2"
       endpoint_auto_confirms = false
       raw_message_delivery   = false
-      filter_policy = "{\"LiteMessageType\":[\"OrderCreated\"]}"
+      filter_policy          = "{\"LiteMessageType\":[\"OrderCreated\"]}"
     },
   ]
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -11,6 +11,7 @@ locals {
       endpoint               = "some_arn"
       endpoint_auto_confirms = true
       raw_message_delivery   = true
+      filter_policy = ""
     },
     {
       name                   = "random_named2"
@@ -19,6 +20,7 @@ locals {
       endpoint               = "some_arn2"
       endpoint_auto_confirms = false
       raw_message_delivery   = false
+      filter_policy = "{\"LiteMessageType\":[\"OrderCreated\"]}"
     },
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -4,5 +4,5 @@ resource "aws_sns_topic_subscription" "this" {
   protocol               = each.value.protocol
   endpoint               = each.value.endpoint
   endpoint_auto_confirms = each.value.endpoint_auto_confirms
-  raw_message_delivery   = lookup(each.value, "raw_message_delivery", null)
+  raw_message_delivery   = each.value.raw_message_delivery
 }

--- a/main.tf
+++ b/main.tf
@@ -5,4 +5,5 @@ resource "aws_sns_topic_subscription" "this" {
   endpoint               = each.value.endpoint
   endpoint_auto_confirms = each.value.endpoint_auto_confirms
   raw_message_delivery   = each.value.raw_message_delivery
+  filter_policy          = each.value.filter_policy
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,7 @@ variable "sns_topic_subscriptions" {
     protocol               = string
     endpoint               = string
     endpoint_auto_confirms = bool
+    raw_message_delivery   = bool
   }))
   default     = []
   description = "SNS Subscriptions"

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,7 @@ variable "sns_topic_subscriptions" {
     endpoint               = string
     endpoint_auto_confirms = bool
     raw_message_delivery   = bool
+    filter_policy          = string
   }))
   default     = []
   description = "SNS Subscriptions"


### PR DESCRIPTION
We need to add the property because optional properties are not possible, see https://github.com/hashicorp/terraform/issues/19898