### PR TITLE
Add Redrive Policy to SNS Subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_sns_topic_subscriptions"></a> [sns\_topic\_subscriptions](#input\_sns\_topic\_subscriptions) | SNS Subscriptions | <pre>list(object({<br>    name                   = string<br>    topic_arn              = string<br>    protocol               = string<br>    endpoint               = string<br>    endpoint_auto_confirms = bool<br>    raw_message_delivery   = bool<br>    filter_policy          = string<br>  }))</pre> | `[]` | no |
+| <a name="input_sns_topic_subscriptions"></a> [sns\_topic\_subscriptions](#input\_sns\_topic\_subscriptions) | SNS Subscriptions | <pre>list(object({<br>    name                   = string<br>    topic_arn              = string<br>    protocol               = string<br>    endpoint               = string<br>    endpoint_auto_confirms = bool<br>    raw_message_delivery   = bool<br>    filter_policy          = string<br>    redrive_policy         = string<br>  }))</pre> | `[]` | no |
 
 ## Outputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -12,6 +12,7 @@ locals {
       endpoint_auto_confirms = true
       raw_message_delivery   = true
       filter_policy          = ""
+      redrive_policy         = null
     },
     {
       name                   = "random_named2"
@@ -21,6 +22,7 @@ locals {
       endpoint_auto_confirms = false
       raw_message_delivery   = false
       filter_policy          = "{\"LiteMessageType\":[\"OrderCreated\"]}"
+      redrive_policy         = "{\"deadLetterTargetArn\": \"arn:aws:sqs:us-east-1:806199016981:MyDeadLetter\"}"
     },
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -6,4 +6,5 @@ resource "aws_sns_topic_subscription" "this" {
   endpoint_auto_confirms = each.value.endpoint_auto_confirms
   raw_message_delivery   = each.value.raw_message_delivery
   filter_policy          = each.value.filter_policy
+  redrive_policy         = each.value.redrive_policy
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,7 @@ variable "sns_topic_subscriptions" {
     endpoint_auto_confirms = bool
     raw_message_delivery   = bool
     filter_policy          = string
+    redrive_policy         = string
   }))
   default     = []
   description = "SNS Subscriptions"


### PR DESCRIPTION
Upcoming release: v0.2.0

This allows for SNS dead letter queues.